### PR TITLE
fixed error handling mechanism

### DIFF
--- a/app/middlewares/security/index.js
+++ b/app/middlewares/security/index.js
@@ -3,34 +3,34 @@ const exc = require('../../core/exceptions');
 var security = {};
 
 security.AcceptJsonOnly = function () {
-  this.process = function (req, resWriter, resHandler) {
+  this.process = function (req, res, exc) {
     if (!req.isJson) {
       throw new exc.UnsupportedMediaType('application/json');
     } else {
-      this.next(req, resWriter, resHandler);
+      this.next(req, res, exc);
     }
   };
 };
 
 security.RequireOnlyJson = function () {
-  this.process = function (req, resWriter, resHandler) {
+  this.process = function (req, res, exc) {
     if (req.headers.accept != 'application/json') {
       throw new exc.NotAcceptable('application/json');
     } else {
-      this.next(req, resWriter, resHandler);
+      this.next(req, res, exc);
     }
   };
 };
 
 security.Common = function () {
-  this.process = function (req, resWriter, resHandler) {
-    resWriter.setHeader('Cache-Control', 'no-store');
-    resWriter.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
-    resWriter.setHeader('X-Content-Type-Options', 'nosniff');
-    resWriter.setHeader('X-Frame-Options', 'DENY');
-    resWriter.setHeader('Referrer-Policy', 'no-referrer');
-    resWriter.setHeader('Feature-Policy', "'none'");
-    this.next(req, resWriter, resHandler);
+  this.process = function (req, res, exc) {
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('Feature-Policy', "'none'");
+    this.next(req, res, exc);
   };
 };
 

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -37,9 +37,9 @@ server.use = function (middleware) {
       server._middlewares[server._middlewares.length - 1].next = function (
         request,
         responseWriter,
-        responseHandler
+        exceptionHandler
       ) {
-        middleware.process(request, responseWriter, responseHandler);
+        middleware.process(request, responseWriter, exceptionHandler);
       };
       // we do it here once, when application starts as opposed
       // to "middleware finalizer logic". Because that "logic"


### PR DESCRIPTION
Now if a service wants to tell about some errors its function must accept
accept "exceptionHandler" callback and pass an error to it instead
of just throwing.

Also middlewares need not to carry responseHandler till the end
of middlewares' chain. They must be defined as regular services except
one thing: they must always accept exceptionHandler callback as 3rd argument
and pass it to the next one in chain.